### PR TITLE
Graceful client shutdown on terminate signals

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,5 +69,14 @@ client.once('ready', () => {
 
 }
 
+process.on('SIGINT', () => {
+    client.destroy();
+});
+
+process.on('SIGTERM', () => {
+    client.destroy();
+});
+
+
 init();
 


### PR DESCRIPTION
When [SIGINT](https://nodejs.org/api/process.html#process_signal_events) is sent (with CTRL + C), the client isn't exited gracefully.

It's not an issue if the bot is entirely text-chat based, but presents some problems when the bot's doing things like joining channels (in which case it'll remain connected for quite a long time).

See [client.destroy()](https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=destroy)

I've tested this on Ubuntu, if someone could double check this on Windows I'd appreciate it.
( "'SIGTERM' is not supported on Windows, it can be listened on.")

